### PR TITLE
fix(execSyncRead): debuggability

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -24,7 +24,7 @@ function execSyncRead(command, silent = false) {
   if (!silent) {
     console.log(normalized);
   }
-  return _.trim(String(cp.execSync(normalized, { stdio: ['pipe', 'pipe', 'pipe'] })));
+  return _.trim(String(cp.execSync(normalized, { stdio: ['inherit', 'pipe', silent ? 'pipe' : 'inherit'] })));
 }
 
 function execAsyncRead(command, silent = false) {


### PR DESCRIPTION
Currently, this function eats all the stderr output, which is bad for non-silent mode.

Sometimes I can't tell what is wrong with the called command.

Also, `stdin` can be `inherit` – we don't do any programmatic tasks with it. 🤷‍♂️ 