### PR TITLE
feat: add execSyncReadStdout method

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -27,6 +27,17 @@ function execSyncRead(command, silent = false) {
   return _.trim(String(cp.execSync(normalized, { stdio: ['pipe', 'pipe', 'pipe'] })));
 }
 
+function execSyncReadStdout(command, silent = false) {
+  const normalized = normalizeSpace(command);
+  if (_.isEmpty(normalized)) {
+    return '';
+  }
+  if (!silent) {
+    console.log(normalized);
+  }
+  return _.trim(String(cp.execSync(normalized, { stdio: ['inherit', 'pipe', 'inherit'] })));
+}
+
 function execAsyncRead(command, silent = false) {
   return execAsync(command, silent).then((resolve) => {
     return _.trim(String(resolve.stdout))
@@ -86,6 +97,7 @@ module.exports = {
   execSync,
   execSyncSilent,
   execSyncRead,
+  execSyncReadStdout,
   execAsyncRead,
   execAsync,
   execAsyncSilent,

--- a/src/exec.test.js
+++ b/src/exec.test.js
@@ -47,7 +47,7 @@ describe('exec', () => {
     expect(fs.existsSync(TESTFILE)).toEqual(true);
     expect(console.log).not.toHaveBeenCalled();
   });
-  
+
   it('execSyncSilent swallows exceptions', () => {
     uut.execSyncSilent(`invalid command`);
   });
@@ -56,8 +56,12 @@ describe('exec', () => {
     expect(() => uut.execSync(`invalid command`)).toThrow();
   });
 
-  it('handles empty input', () => {
+  it('execSyncRead handles empty input', () => {
     expect(uut.execSyncRead()).toEqual('');
+  });
+
+  it('execSyncReadStdout handles empty input', () => {
+    expect(uut.execSyncReadStdout()).toEqual('');
   });
 
   it('execSyncRead returns the stdout as string', () => {
@@ -69,6 +73,19 @@ describe('exec', () => {
   it('execSyncRead with silent param', () => {
     uut.execSyncSilent(`echo "hello world!" > ${TESTFILE}`);
     const result = uut.execSyncRead(`cat ${TESTFILE}`, true);
+    expect(result).toEqual('hello world!');
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('execSyncReadStdout returns the stdout as string', () => {
+    uut.execSync(`echo "hello world!" > ${TESTFILE}`);
+    const result = uut.execSyncReadStdout(`cat ${TESTFILE}`);
+    expect(result).toEqual('hello world!');
+  });
+
+  it('execSyncReadStdout with silent param', () => {
+    uut.execSyncSilent(`echo "hello world!" > ${TESTFILE}`);
+    const result = uut.execSyncReadStdout(`cat ${TESTFILE}`, true);
     expect(result).toEqual('hello world!');
     expect(console.log).not.toHaveBeenCalled();
   });
@@ -87,7 +104,6 @@ describe('exec', () => {
   });
 
   it('execAsyncRead should reject on invalid command', async () => {
-
     try {
       const result = await uut.execAsyncRead(`invalid command`);
       fail('should throw');
@@ -107,6 +123,20 @@ describe('exec', () => {
 
   it('execSyncRead throws on exception', () => {
     expect(() => uut.execSyncRead(`invalid command`)).toThrow();
+  });
+
+  it('execSyncRead prints only stdout into thrown exception', () => {
+    try {
+      uut.execSyncReadStdout(`npm view 999999999`);
+      fail('should throw');
+    } catch (e) {
+      expect(e.toString()).not.toContain(`npm ERR! 404`);
+      expect(e.toString()).toContain(`Error: Command failed: npm view`);
+    }
+  });
+
+  it('execSyncRead throws on exception', () => {
+    expect(() => uut.execSyncReadStdout(`invalid command`)).toThrow();
   });
 
   it('which', () => {


### PR DESCRIPTION
This PR contains the fix @noomorph pushed in https://github.com/wix/shell-utils/pull/17, after reverting it due to unit tests regression.

> Currently, this function eats all the stderr output, which is bad for non-silent mode.
> 
> Sometimes I can't tell what is wrong with the called command.
> 
> Also, `stdin` can be `inherit` – we don't do any programmatic tasks with it. 🤷‍♂️ 